### PR TITLE
Update actions-runner image to the version that worked

### DIFF
--- a/self-hosted-runners/Dockerfile
+++ b/self-hosted-runners/Dockerfile
@@ -1,4 +1,4 @@
-FROM summerwind/actions-runner:latest
+FROM summerwind/actions-runner:v2.289.1-ubuntu-20.04
 
 RUN sudo apt update -y \
   && sudo apt -y install azure-cli \


### PR DESCRIPTION
# What does this change do?

Update actions-runner image to the version that worked before. Currently, self-hosted runners are not kicking off the "Set up Docker Buildx" stage. This should help revert to a version that works. 

Version that showed it worked: https://github.com/submittable/github-actions/runs/5792148395?check_suite_focus=true

# Please include a link to the Change Request or Agile Story here
Jira ticket: SUB-5346