### PR TITLE
Revert "Update actions-runner image to the version that worked"

### DIFF
--- a/self-hosted-runners/Dockerfile
+++ b/self-hosted-runners/Dockerfile
@@ -1,4 +1,4 @@
-FROM summerwind/actions-runner:v2.289.1-ubuntu-20.04
+FROM summerwind/actions-runner:latest
 
 RUN sudo apt update -y \
   && sudo apt -y install azure-cli \


### PR DESCRIPTION
Reverts submittable/github-actions#22

Error appearing in pod that recreated with this Dockerfile:
```
Current runner version: '2.289.1'
2022-05-13 15:28:01Z: Listening for Jobs
An error occurred: Runner version v2.289.1 is deprecated and cannot receive messages.
```