### PR TITLE
Develop/test/johnyacuta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,7 @@ jobs:
          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
       - name: Run Sonar Scan - Python
+        run: echo SONAR_HOST_URL - ${{ secrets.SONAR_HOST_URL }}
         if: ${{ inputs.sonar-python == 'true' }}
         uses: sonarsource/sonarqube-scan-action@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,6 @@ jobs:
          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
       - name: Run Sonar Scan - Python
-        # run: echo SONAR_HOST_URL - ${{ secrets.SONAR_HOST_URL }}
         if: ${{ inputs.sonar-python == 'true' }}
         uses: sonarsource/sonarqube-scan-action@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest # self-hosted
+    runs-on: [self-hosted, linux] # ubuntu-latest
     env:
       SonarDotNet: ${{ inputs.sonar-dotnet }}
       SonarPython: ${{ inputs.sonar-python }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,6 @@ on:
       repo_name:
         required: true
         type: string
-      # branch_name:
-      #   required: true
-      #   type: string
       image_name:
         required: true
         type: string
@@ -98,7 +95,7 @@ on:
 jobs:
   build:
 
-    runs-on: [self-hosted, linux] # ubuntu-latest
+    runs-on: [self-hosted, linux]
     env:
       SonarDotNet: ${{ inputs.sonar-dotnet }}
       SonarPython: ${{ inputs.sonar-python }}
@@ -136,29 +133,6 @@ jobs:
         with:
           driver: docker
       
-      # Try using the latest action library
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v2
-      #   with:
-      #     buildkitd-flags: --debug
-      
-      # Try using K8s driver with build
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v2
-      #   with:
-      #     driver: kubernetes
-      
-      # - name: Build
-      #   run: |
-      #     buildx build .
-
-      # Try using custom commands for buildx
-      # - name: Install Docker Buildx
-      #   run: |
-      #     mkdir -p "$HOME/.docker/cli-plugins"
-      #     curl -SsL "https://github.com/docker/buildx/releases/download/v0.7.1/buildx-v0.7.1.linux-amd64" -o "$HOME/.docker/cli-plugins/docker-buildx"
-      #     chmod +x "$HOME/.docker/cli-plugins/docker-buildx"
-      
       - name: Check file existence for Nodejs
         id: check_files_nodejs
         uses: submittable/file-existence-action@v1
@@ -181,9 +155,9 @@ jobs:
         if: steps.check_files_dotnet.outputs.files_exists == 'true'
         uses: Nuget/setup-nuget@v1.0.5
       
-#       - name: Add msbuild to PATH
-#         if: steps.check_files_dotnet.outputs.files_exists == 'true'
-#         uses: microsoft/setup-msbuild@v1.0.2
+      # - name: Add msbuild to PATH
+      #   if: steps.check_files_dotnet.outputs.files_exists == 'true'
+      #   uses: microsoft/setup-msbuild@v1.0.2
 
       - name: Check file existence for Dockerfile
         id: check_files_docker
@@ -265,12 +239,12 @@ jobs:
         if: steps.check_files_python_test.outputs.files_exists == 'true'
         run: python -m unittest discover tests
 
-#Build fails running tests, so commenting until we have a working test case
-#       - name: Run .Net test with .Net CLI
-#         if: steps.check_files_dotnet.outputs.files_exists == 'true'
-#         run: dotnet test --settings coverlet.runsettings --logger:trx
-#         env:
-#           ASPNETCORE_ENVIRONMENT: Development
+      # Build fails running tests, so commenting until we have a working test case
+      # - name: Run .Net test with .Net CLI
+      #   if: steps.check_files_dotnet.outputs.files_exists == 'true'
+      #   run: dotnet test --settings coverlet.runsettings --logger:trx
+      #   env:
+      #     ASPNETCORE_ENVIRONMENT: Development
 
       - name: Archive production artifacts
         if: steps.check_files_nodejs_test.outputs.files_exists == 'true'
@@ -288,16 +262,6 @@ jobs:
           name: code-coverage-report
           path: output/test/code-coverage.html
           retention-days: 5
-      
-      # We need to set the proxy for SDM so we can access websites
-      # - name: Set proxy for SDM
-      #   run: |
-      #     export HTTP_PROXY="http://localhost:65230"
-      #     env | grep PROXY
-      #     curl -k -x localhost:65230 $SONAR_HOST_URL
-      #   shell: sh
-      #   env:
-      #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
     
       # Enable only when Sonar server is available. It will run Static Code Analysis
       - name: Run Sonar Scan - Nodejs
@@ -364,20 +328,10 @@ jobs:
           TEMP=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           echo "##[set-output name=branch;]$(echo ${TEMP///-})"
         id: extract_ref_tag
-
-      # # Test: move this to here so we can test sonarqube
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v1
-
-      # # Test: move this to here so we can test sonarqube
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v1
-      #   with:
-      #     driver: docker
       
       # Collate the image name, tags, and labels for push command
       - name: Extract metadata (tags, labels)
-#         if: steps.check_files_docker.outputs.files_exists == 'true'
+        # if: steps.check_files_docker.outputs.files_exists == 'true'
         id: meta
         uses: docker/metadata-action@v3.5.0
         with:
@@ -390,7 +344,7 @@ jobs:
       
       # Build, Tag and Push the docker image to Github Container Registry
       - name: Build, Tag and Push Docker Image
-#         if: steps.check_files_docker.outputs.files_exists == 'true'
+        # if: steps.check_files_docker.outputs.files_exists == 'true'
         uses: docker/build-push-action@v2.7.0
         with:
           context: ${{ inputs.context }}
@@ -411,8 +365,6 @@ jobs:
           tag_name: ${{ steps.tag_version.outputs.new_tag }}
           release_name: ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
-
-      # - name: Update Image
 
       # Sends a slack notification to slack build channel on Success
       - name: Slack Notification - On Success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,11 +134,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          driver: kubernetes
+          buildkitd-flags: --debug
       
-      - name: Build
-        run: |
-          buildx build .
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v2
+      #   with:
+      #     driver: kubernetes
+      
+      # - name: Build
+      #   run: |
+      #     buildx build .
 
       # - name: Install Docker Buildx
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
       - name: Run Sonar Scan - Python
-        run: echo SONAR_HOST_URL - ${{ secrets.SONAR_HOST_URL }}
+        # run: echo SONAR_HOST_URL - ${{ secrets.SONAR_HOST_URL }}
         if: ${{ inputs.sonar-python == 'true' }}
         uses: sonarsource/sonarqube-scan-action@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,10 @@ jobs:
       #     curl -SsL "https://github.com/docker/buildx/releases/download/v0.7.1/buildx-v0.7.1.linux-amd64" -o "$HOME/.docker/cli-plugins/docker-buildx"
       #     chmod +x "$HOME/.docker/cli-plugins/docker-buildx"
       
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          driver: docker
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v1
+      #   with:
+      #     driver: docker
           # buildkitd-flags: --debug
           # buildkitd-flags: --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
           # install: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,10 +138,13 @@ jobs:
       #     chmod +x "$HOME/.docker/cli-plugins/docker-buildx"
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2 # docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v1
         with:
           # buildkitd-flags: --debug
-          driver: docker-container # docker
+          driver: docker
+          buildkitd-flags: --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
+          install: false
+          use: true
       
       - name: Check file existence for Nodejs
         id: check_files_nodejs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted # ubuntu-latest
     env:
       SonarDotNet: ${{ inputs.sonar-dotnet }}
       SonarPython: ${{ inputs.sonar-python }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,13 +128,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v1
-      #   with:
-      #     driver: docker
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver: docker
       
       # Try using the latest action library
       # - name: Set up Docker Buildx
@@ -365,15 +365,15 @@ jobs:
           echo "##[set-output name=branch;]$(echo ${TEMP///-})"
         id: extract_ref_tag
 
-      # Test: move this to here so we can test sonarqube
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+      # # Test: move this to here so we can test sonarqube
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v1
 
-      # Test: move this to here so we can test sonarqube
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          driver: docker
+      # # Test: move this to here so we can test sonarqube
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v1
+      #   with:
+      #     driver: docker
       
       # Collate the image name, tags, and labels for push command
       - name: Extract metadata (tags, labels)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,12 +130,18 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+
+      - name: Install Docker Buildx
+        run: |
+          mkdir -p "$HOME/.docker/cli-plugins"
+          curl -SsL "https://github.com/docker/buildx/releases/download/v0.7.1/buildx-v0.7.1.linux-amd64" -o "$HOME/.docker/cli-plugins/docker-buildx"
+          chmod +x "$HOME/.docker/cli-plugins/docker-buildx"
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          buildkitd-flags: --debug
-          driver: docker
+        # with:
+        #   buildkitd-flags: --debug
+        #   driver: docker
       
       - name: Check file existence for Nodejs
         id: check_files_nodejs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ on:
 jobs:
   build:
 
-    runs-on: self-hosted # ubuntu-latest
+    runs-on: ubuntu-latest # self-hosted
     env:
       SonarDotNet: ${{ inputs.sonar-dotnet }}
       SonarPython: ${{ inputs.sonar-python }}
@@ -128,8 +128,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+      # - name: Set up QEMU
+      #   uses: docker/setup-qemu-action@v1
+      
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v1
+      #   with:
+      #     driver: docker
       
       # Try using the latest action library
       # - name: Set up Docker Buildx
@@ -153,14 +158,6 @@ jobs:
       #     mkdir -p "$HOME/.docker/cli-plugins"
       #     curl -SsL "https://github.com/docker/buildx/releases/download/v0.7.1/buildx-v0.7.1.linux-amd64" -o "$HOME/.docker/cli-plugins/docker-buildx"
       #     chmod +x "$HOME/.docker/cli-plugins/docker-buildx"
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          driver: docker
-          # buildkitd-flags: --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
-          # install: false
-          # use: true
       
       - name: Check file existence for Nodejs
         id: check_files_nodejs
@@ -357,6 +354,16 @@ jobs:
           TEMP=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           echo "##[set-output name=branch;]$(echo ${TEMP///-})"
         id: extract_ref_tag
+
+      # Test: move this to here so we can test sonarqube
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      # Test: move this to here so we can test sonarqube
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver: docker
       
       # Collate the image name, tags, and labels for push command
       - name: Extract metadata (tags, labels)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ on:
 jobs:
   build:
 
-    runs-on: [self-hosted, linux, x64] # ubuntu-latest
+    runs-on: self-hosted # ubuntu-latest
     env:
       SonarDotNet: ${{ inputs.sonar-dotnet }}
       SonarPython: ${{ inputs.sonar-python }}
@@ -131,10 +131,10 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          buildkitd-flags: --debug
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v2
+      #   with:
+      #     buildkitd-flags: --debug
       
       # - name: Set up Docker Buildx
       #   uses: docker/setup-buildx-action@v2
@@ -151,10 +151,10 @@ jobs:
       #     curl -SsL "https://github.com/docker/buildx/releases/download/v0.7.1/buildx-v0.7.1.linux-amd64" -o "$HOME/.docker/cli-plugins/docker-buildx"
       #     chmod +x "$HOME/.docker/cli-plugins/docker-buildx"
       
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v1
-      #   with:
-      #     driver: docker
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver: docker
           # buildkitd-flags: --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
           # install: false
           # use: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,11 +131,13 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       
+      # Try using the latest action library
       # - name: Set up Docker Buildx
       #   uses: docker/setup-buildx-action@v2
       #   with:
       #     buildkitd-flags: --debug
       
+      # Try using K8s driver with build
       # - name: Set up Docker Buildx
       #   uses: docker/setup-buildx-action@v2
       #   with:
@@ -145,6 +147,7 @@ jobs:
       #   run: |
       #     buildx build .
 
+      # Try using custom commands for buildx
       # - name: Install Docker Buildx
       #   run: |
       #     mkdir -p "$HOME/.docker/cli-plugins"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ on:
       repo_name:
         required: true
         type: string
+      branch_name:
+        required: true
+        type: string
       image_name:
         required: true
         type: string

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,14 +290,14 @@ jobs:
           retention-days: 5
       
       # We need to set the proxy for SDM so we can access websites
-      - name: Set proxy for SDM
-        run: |
-          export HTTP_PROXY="http://localhost:65230"
-          env | grep PROXY
-          curl -k -x localhost:65230 $SONAR_HOST_URL
-        shell: sh
-        env:
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      # - name: Set proxy for SDM
+      #   run: |
+      #     export HTTP_PROXY="http://localhost:65230"
+      #     env | grep PROXY
+      #     curl -k -x localhost:65230 $SONAR_HOST_URL
+      #   shell: sh
+      #   env:
+      #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
     
       # Enable only when Sonar server is available. It will run Static Code Analysis
       - name: Run Sonar Scan - Nodejs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,11 +140,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
-          # buildkitd-flags: --debug
           driver: docker
-          buildkitd-flags: --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
-          install: false
-          use: true
+          # buildkitd-flags: --debug
+          # buildkitd-flags: --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
+          # install: false
+          # use: true
       
       - name: Check file existence for Nodejs
         id: check_files_nodejs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ on:
 jobs:
   build:
 
-    runs-on: self-hosted # ubuntu-latest
+    runs-on: [self-hosted, linux, x64] # ubuntu-latest
     env:
       SonarDotNet: ${{ inputs.sonar-dotnet }}
       SonarPython: ${{ inputs.sonar-python }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,15 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          driver: kubernetes
+      
+      - name: Build
+        run: |
+          buildx build .
 
       # - name: Install Docker Buildx
       #   run: |
@@ -141,7 +150,6 @@ jobs:
       #   uses: docker/setup-buildx-action@v1
       #   with:
       #     driver: docker
-          # buildkitd-flags: --debug
           # buildkitd-flags: --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
           # install: false
           # use: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
         with:
+          buildkitd-flags: --debug
           driver: docker
       
       - name: Check file existence for Nodejs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,17 +131,17 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
-      - name: Install Docker Buildx
-        run: |
-          mkdir -p "$HOME/.docker/cli-plugins"
-          curl -SsL "https://github.com/docker/buildx/releases/download/v0.7.1/buildx-v0.7.1.linux-amd64" -o "$HOME/.docker/cli-plugins/docker-buildx"
-          chmod +x "$HOME/.docker/cli-plugins/docker-buildx"
+      # - name: Install Docker Buildx
+      #   run: |
+      #     mkdir -p "$HOME/.docker/cli-plugins"
+      #     curl -SsL "https://github.com/docker/buildx/releases/download/v0.7.1/buildx-v0.7.1.linux-amd64" -o "$HOME/.docker/cli-plugins/docker-buildx"
+      #     chmod +x "$HOME/.docker/cli-plugins/docker-buildx"
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        # with:
-        #   buildkitd-flags: --debug
-        #   driver: docker
+        uses: docker/setup-buildx-action@v2 # docker/setup-buildx-action@v1
+        with:
+          # buildkitd-flags: --debug
+          driver: docker-container # docker
       
       - name: Check file existence for Nodejs
         id: check_files_nodejs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,8 +288,18 @@ jobs:
           name: code-coverage-report
           path: output/test/code-coverage.html
           retention-days: 5
+      
+      # We need to set the proxy for SDM so we can access websites
+      - name: Set proxy for SDM
+        run: |
+          export HTTP_PROXY="http://localhost:65230"
+          env | grep PROXY
+          curl -k -x localhost:65230 $SONAR_HOST_URL
+        shell: sh
+        env:
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
     
-    #Enable only when Sonar server is available. It will run Static Code Analysis
+      # Enable only when Sonar server is available. It will run Static Code Analysis
       - name: Run Sonar Scan - Nodejs
         if: ${{ inputs.sonar-nodejs == 'true' }}
         uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,9 @@ on:
       repo_name:
         required: true
         type: string
-      branch_name:
-        required: true
-        type: string
+      # branch_name:
+      #   required: true
+      #   type: string
       image_name:
         required: true
         type: string

--- a/self-hosted-runners/Dockerfile
+++ b/self-hosted-runners/Dockerfile
@@ -1,4 +1,4 @@
-FROM summerwind/actions-runner:v2.289.2-ubuntu-20.04
+FROM summerwind/actions-runner:v2.289.1-ubuntu-20.04
 
 RUN sudo apt update -y \
   && sudo apt -y install azure-cli \

--- a/self-hosted-runners/Dockerfile
+++ b/self-hosted-runners/Dockerfile
@@ -1,4 +1,4 @@
-FROM summerwind/actions-runner:v2.289.1-ubuntu-20.04
+FROM summerwind/actions-runner:latest
 
 RUN sudo apt update -y \
   && sudo apt -y install azure-cli \

--- a/self-hosted-runners/Dockerfile
+++ b/self-hosted-runners/Dockerfile
@@ -1,4 +1,4 @@
-FROM summerwind/actions-runner:latest
+FROM summerwind/actions-runner:v2.289.2-ubuntu-20.04
 
 RUN sudo apt update -y \
   && sudo apt -y install azure-cli \


### PR DESCRIPTION
# What does this change do?

This change enables self-hosted runners running on Linux to use runners hosted in Kubernetes. 

This used to not work before but has been resolved in infrastructure. If this does not work again, then the quickest solution is to set the `run-on` method to `ubuntu-latest` which would go back to GitHub hosted runners.

This change has been tested using the following repositories:
1. Internal tool 1
2. Internal tool 2

# Here's an awesome image for your troubles
The GitHub runners
![image](https://www.nih.gov/sites/default/files/styles/floated_media_breakpoint-large/public/news-events/research-matters/2019/20190723-running.jpg?itok=OdGm1puN&timestamp=1563816294)

# Please include a link to the Change Request or Agile Story here
https://submishmash.atlassian.net/browse/SUB-5346
