### PR TITLE
Update Python and SonarQube

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
       
       - name: Run Python tests
         if: steps.check_files_python_test.outputs.files_exists == 'true'
-        run: python -m pytest --cov-report xml:coverage-reports/coverage.xml --cov . # python -m unittest discover tests
+        run: python -m pytest --cov-report xml:coverage-reports/coverage.xml --cov .
 
       # Build fails running tests, so commenting until we have a working test case
       # - name: Run .Net test with .Net CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
         with:
           projectBaseDir: .
           args: >
-            -Dsonar.python.coverage.reportPaths=coverage.xml
+            -Dsonar.python.coverage.reportPaths=coverage-reports/coverage.xml
             -Dsonar.verbose=true
             -Dsonar.projectKey=${{ inputs.repo_name }}
             -Dsonar.sources=.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,12 +255,20 @@ jobs:
             dist
             !dist/**/*.md
 
-      - name: Archive code coverage results
+      - name: Archive code coverage results - Nodejs
         if: steps.check_files_nodejs_test.outputs.files_exists == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: code-coverage-report
           path: output/test/code-coverage.html
+          retention-days: 5
+      
+      - name: Archive code coverage results - Python
+        if: steps.check_files_python_test.outputs.files_exists == 'true'
+        uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage-report
+          path: coverage-reports/coverage.xml
           retention-days: 5
     
     #Enable only when Sonar server is available. It will run Static Code Analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
       
       - name: Run Python tests
         if: steps.check_files_python_test.outputs.files_exists == 'true'
-        run: python -m unittest discover tests
+        run: python -m pytest --cov-report xml:coverage.xml --cov . # python -m unittest discover tests
 
 #Build fails running tests, so commenting until we have a working test case
 #       - name: Run .Net test with .Net CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
       
       - name: Run Python tests
         if: steps.check_files_python_test.outputs.files_exists == 'true'
-        run: python -m pytest --cov-report xml:coverage.xml --cov . # python -m unittest discover tests
+        run: python -m pytest --cov-report xml:coverage-reports/coverage.xml --cov . # python -m unittest discover tests
 
 #Build fails running tests, so commenting until we have a working test case
 #       - name: Run .Net test with .Net CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux] # ubuntu-latest
     env:
       SonarDotNet: ${{ inputs.sonar-dotnet }}
       SonarPython: ${{ inputs.sonar-python }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,8 @@ jobs:
             -Dsonar.verbose=true
             -Dsonar.projectKey=${{ inputs.repo_name }}
             -Dsonar.sources=.
+            -Dsonar.tests=tests/
+            -Dsonar.exclusions=tests/**
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}


### PR DESCRIPTION
# What does this change do?

- Update `Run Python tests` step with pytest and code coverage generation for SonarQube
- Add new step `Archive code coverage results - Python` for archiving Python code coverage report for SonarQube
- Update `Run Sonar Scan - Python` step with additional args for SonarQube

Note: SonarQube open source deployment only scans for `master/main` branches so I need to merge this first and then merge a feature branch in another Python repo to confirm the test code coverage report is pushed and detected by SonarQube. 

# Here's an awesome image for your troubles
![image](https://www.sonarqube.org/assets/logo-31ad3115b1b4b120f3d1efd63e6b13ac9f1f89437f0cf6881cc4d8b5603a52b4.svg)

# Please include a link to the Change Request or Agile Story here

https://submishmash.atlassian.net/browse/SUB-5412
