### PR TITLE
Revert "Revert "[SUB-5648] Design Reusable CI Pipeline v3""

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,89 +1,118 @@
-name: Test, Sonar Scan and Docker Build-Push Workflow
+name: Submittable CI Workflow
 
 on:
   workflow_call:
     inputs:
+      # ---------------------------------------------------------
+      # General project properties
+      # ---------------------------------------------------------
+      repo_name:
+        description: 'The repository name e.g. hello-world'
+        default: '${{ github.event.repository.name }}'
+        required: false
+        type: string
+      image_name:
+        description: 'The owner and repository name e.g. submittable/hello-world'
+        default: '${{ github.repository }}'
+        required: false
+        type: string
       sem-release:
         description: Whether to run a semantic release
-        required: false
-        type: string
         default: 'true'
-      sonar-python:
-        description: Whether to Scan code using SonarQube
         required: false
         type: string
-        default: 'false'
-      sonar-nodejs:
-        description: Whether to Scan code using SonarQube
+      file:
+        description: 'Adds the path to the dockerfile ./Dockerfile or root Dockerfile'
+        default: 'Dockerfile'
         required: false
         type: string
-        default: 'false'
-      sonar-dotnet:
-        description: Whether to Scan code using SonarQube
+      context:
+        description: 'Adds the context path to the dockerfile'
+        default: '.'
         required: false
         type: string
-        default: 'false'
+      
+      # ---------------------------------------------------------
+      # .NET project properties
+      # ---------------------------------------------------------
       dotnetbuildarguments:
         description: 'Optional command arguments to dotnet build'
         default: 'nofile'
         required: false
         type: string
-      nodejs_version:
-        description: 'sets node version'
-        default: '15.x'
+
+      # ---------------------------------------------------------
+      # Check to enable SonrQube scan for project
+      # ---------------------------------------------------------
+      sonar-python:
+        description: Whether to Scan code using SonarQube
+        default: 'false'
         required: false
         type: string
-      python_version:
-        description: 'sets python version'
-        default: '3.6'
+      sonar-nodejs:
+        description: Whether to Scan code using SonarQube
+        default: 'false'
         required: false
         type: string
-      dotnet_version:
-        description: 'sets .net version for dotnet core application'
-        default: '5.0.x'
+      sonar-dotnet:
+        description: Whether to Scan code using SonarQube
+        default: 'false'
         required: false
         type: string
-      file_check_path_nodejs_test:
-        description: 'checks file path to enable nodejs unit test'
-        default: "nofile"
-        required: false
-        type: string
-      file_check_path_python_test:
-        description: 'checks file path to enable python unit test'
-        default: "nofile"
-        required: false
-        type: string
+      
+      # ---------------------------------------------------------
+      # Identify project
+      # ---------------------------------------------------------
       file_check_path_python:
-        description: 'checks file path to identify as a python pipeline job'
-        default: "nofile"
+        description: 'Checks file path to identify as a python pipeline job'
+        default: "requirements.txt"
         required: false
         type: string
       file_check_path_nodejs:
-        description: 'checks file path to identify as a nodejs pipeline job'
-        default: "nofile"
+        description: 'Checks file path to identify as a nodejs pipeline job'
+        default: "package.json"
         required: false
         type: string
       file_check_path_dotnet:
-        description: 'checks file path to identify as a dotnet pipeline job'
-        default: "nofile"
+        description: 'Checks file path to identify as a dotnet pipeline job'
+        default: "*.sln"
         required: false
         type: string
-      repo_name:
-        required: true
-        type: string
-      image_name:
-        required: true
-        type: string
-      file:
-        description: 'adds the path to the dockerfile ./Dockerfile or root Dockerfile'
-        default: 'Dockerfile'
+      
+      # ---------------------------------------------------------
+      # Identify project version
+      # ---------------------------------------------------------
+      python_version:
+        description: 'Sets python version'
+        default: '3.6'
         required: false
         type: string
-      context:
-        description: 'adds the context path to the dockerfile'
-        default: '.'
+      nodejs_version:
+        description: 'Sets node version'
+        default: '15.x'
         required: false
         type: string
+      dotnet_version:
+        description: 'Sets .NET version for .NET core application'
+        default: '5.0.x'
+        required: false
+        type: string
+      
+      # ---------------------------------------------------------
+      # Identify the location of the unit tests
+      # ---------------------------------------------------------
+      file_check_path_python_test:
+        description: 'Checks file path to enable python unit test'
+        default: "tests/__init__.py"
+        required: false
+        type: string
+      file_check_path_nodejs_test:
+        description: 'Checks file path to enable node unit test'
+        default: "src/__tests__/*.test.js"
+        required: false
+        type: string
+      # TODO: file_check_path_dotnet_test
+      
     secrets:
       SLACK_WEBHOOK:
         required: true
@@ -93,57 +122,46 @@ on:
         required: true
 
 jobs:
-  build:
-
+  # ---------------------------------------------------------------------
+  # 1. Setup the CI workflow with dependencies and project properties
+  # ---------------------------------------------------------------------
+  setup:
+    name: Setup Workflow
     runs-on: [self-hosted, linux]
-    env:
-      SonarDotNet: ${{ inputs.sonar-dotnet }}
-      SonarPython: ${{ inputs.sonar-python }}
-      SonarNodeJS: ${{ inputs.sonar-nodejs }}
 
     steps:
+      - name: Submittable CI Workflow started
+        run: echo "✅🎉 Submittable CI Workflow started ✅🎉"
 
-      - name: ✅🎉Universal Reusable Workflow 2.0 started✅🎉
-        run: echo Universal Reusable Workflow 2.0 started!
+  # ---------------------------------------------------------------------
+  # 2. Run tests and send SonarQube coverage report
+  # ---------------------------------------------------------------------
+  test:
+    name: Run Tests
+    runs-on: [self-hosted, linux]
+    needs: setup
 
-      - name: Check for SonarScan value
-        run: |
-          echo "Sonar-Nodejs value is: $SonarNodeJS"
-          echo "Sonar-Python value is: $SonarPython"
-          echo "Sonar-DotNet value is: $SonarDotNet"
-
+    steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          # Disabling shallow clone is recommended for improving relevancy of sonarqube reporting
+          # Disabling shallow clone is recommended for improving relevancy of SonarQube reporting
           fetch-depth: 0
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          driver: docker
-      
-      - name: Check file existence for Nodejs
-        id: check_files_nodejs
-        uses: submittable/file-existence-action@v1
-        with:
-          files: "${{ inputs.file_check_path_nodejs }}"
-      
+      # ---------------------------------------------------------
+      # Identify project
+      # ---------------------------------------------------------
       - name: Check file existence for Python
         id: check_files_python
         uses: submittable/file-existence-action@v1
         with:
           files: "${{ inputs.file_check_path_python }}"
+
+      - name: Check file existence for Nodejs
+        id: check_files_nodejs
+        uses: submittable/file-existence-action@v1
+        with:
+          files: "${{ inputs.file_check_path_nodejs }}"
       
       - name: Check file existence for .Net
         id: check_files_dotnet
@@ -151,55 +169,34 @@ jobs:
         with:
           files: "${{ inputs.file_check_path_dotnet }}"
       
-      - name: Setup Nuget
-        if: steps.check_files_dotnet.outputs.files_exists == 'true'
-        uses: Nuget/setup-nuget@v1.0.5
-      
-      # - name: Add msbuild to PATH
-      #   if: steps.check_files_dotnet.outputs.files_exists == 'true'
-      #   uses: microsoft/setup-msbuild@v1.0.2
-
-      - name: Check file existence for Dockerfile
-        id: check_files_docker
-        uses: submittable/file-existence-action@v1
-        with:
-          files: "Dockerfile"
-
-      - name: Check file existence for Node Testfiles
-        id: check_files_nodejs_test
-        uses: submittable/file-existence-action@v1
-        with:
-          files: "${{ inputs.file_check_path_nodejs_test }}"
-      
-      - name: Check file existence for Python Testfiles
-        id: check_files_python_test
-        uses: submittable/file-existence-action@v1
-        with:
-          files: "${{ inputs.file_check_path_python_test }}"
-
-      - name: Set Node Version
-        if: steps.check_files_nodejs.outputs.files_exists == 'true'
-        # Only runs if all of the files exists
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ inputs.nodejs_version }}
-      
+      # ---------------------------------------------------------
+      # Identify project version
+      # ---------------------------------------------------------
       - name: Set Python Version
         if: steps.check_files_python.outputs.files_exists == 'true'
         uses: actions/setup-python@v2
         with:
           python-version: ${{ inputs.python_version }}
       
-      - name: Setup DotNet Version
+      - name: Set Node Version
+        if: steps.check_files_nodejs.outputs.files_exists == 'true'
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ inputs.nodejs_version }}
+        
+      - name: Set .Net Version
         if: steps.check_files_dotnet.outputs.files_exists == 'true'
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '${{ inputs.dotnet_version }}'
       
-      - name: Install Nodejs Dependencies
-        if: steps.check_files_nodejs.outputs.files_exists == 'true'
-        run: npm ci
+      - name: Setup Nuget
+        if: steps.check_files_dotnet.outputs.files_exists == 'true'
+        uses: Nuget/setup-nuget@v1.0.5
       
+      # ---------------------------------------------------------
+      # Install project dependencies
+      # ---------------------------------------------------------
       - name: Install Python Dependencies
         if: steps.check_files_python.outputs.files_exists == 'true'
         run: |
@@ -207,44 +204,92 @@ jobs:
           pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       
-      - name: Install DotNet dependencies
-        if: steps.check_files_dotnet.outputs.files_exists == 'true'
-        run: dotnet restore
-
-      - name: Build Nodejs App
+      - name: Install Nodejs Dependencies
         if: steps.check_files_nodejs.outputs.files_exists == 'true'
-        run: npm run build --if-present
+        run: npm ci
       
-      - name: Build Python App
-        if: steps.check_files_python.outputs.files_exists == 'true'
-        run: |
-          # stop the build if there are Python syntax errors or undefined names
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --select=E9,F63,F7,F82 --exit-zero --max-complexity=10 --max-line-length=127 --show-source --statistics
-        
-      - name: Restore nuget packages
+      - name: Install .Net dependencies
         if: steps.check_files_dotnet.outputs.files_exists == 'true'
         run: dotnet restore
-        # run: nuget restore ./${{ inputs.file_check_path_dotnet }}
-      
-      - name: Build DotNet App
-        if: steps.check_files_dotnet.outputs.files_exists == 'true'
-        run: dotnet build
 
+      # ---------------------------------------------------------
+      # Identify the location of the unit tests
+      # ---------------------------------------------------------
+      - name: Check file existence for Python Testfiles
+        if: steps.check_files_python.outputs.files_exists == 'true'
+        id: check_files_python_test
+        uses: submittable/file-existence-action@v1
+        with:
+          files: "${{ inputs.file_check_path_python_test }}"
+      
+      - name: Check file existence for Node Testfiles
+        if: steps.check_files_nodejs.outputs.files_exists == 'true'
+        id: check_files_nodejs_test
+        uses: submittable/file-existence-action@v1
+        with:
+          files: "${{ inputs.file_check_path_nodejs_test }}"
+
+      # TODO: Check file existence for .NET Testfiles
+      
+      # ---------------------------------------------------------
+      # Run tests
+      # ---------------------------------------------------------
+      - name: Run Python tests
+        if: steps.check_files_python_test.outputs.files_exists == 'true'
+        run: python -m pytest --cov-report xml:coverage-reports/coverage.xml --cov .
+      
       - name: Run Nodejs tests
         if: steps.check_files_nodejs_test.outputs.files_exists == 'true'
         run: npm test
       
-      - name: Run Python tests
-        if: steps.check_files_python_test.outputs.files_exists == 'true'
-        run: python -m pytest --cov-report xml:coverage-reports/coverage.xml --cov .
-
       # Build fails running tests, so commenting until we have a working test case
       # - name: Run .Net test with .Net CLI
       #   if: steps.check_files_dotnet.outputs.files_exists == 'true'
       #   run: dotnet test --settings coverlet.runsettings --logger:trx
       #   env:
       #     ASPNETCORE_ENVIRONMENT: Development
+
+      # ---------------------------------------------------------
+      # Build the project
+      # ---------------------------------------------------------
+      - name: Build Python App
+        if: steps.check_files_python.outputs.files_exists == 'true'
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --select=E9,F63,F7,F82 --exit-zero --max-complexity=10 --max-line-length=127 --show-source --statistics
+
+      - name: Build Nodejs App
+        if: steps.check_files_nodejs.outputs.files_exists == 'true'
+        run: npm run build --if-present
+        
+      - name: Restore nuget packages
+        if: steps.check_files_dotnet.outputs.files_exists == 'true'
+        run: dotnet restore
+        # run: nuget restore ./${{ inputs.file_check_path_dotnet }}
+      
+      - name: Build .Net App
+        if: steps.check_files_dotnet.outputs.files_exists == 'true'
+        run: dotnet build
+
+      # ---------------------------------------------------------
+      # Archive coverage report and artifacts
+      # ---------------------------------------------------------
+      - name: Archive code coverage results - Python
+        if: steps.check_files_python_test.outputs.files_exists == 'true'
+        uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage-report
+          path: coverage-reports/coverage.xml
+          retention-days: 5
+      
+      - name: Archive code coverage results - Nodejs
+        if: steps.check_files_nodejs_test.outputs.files_exists == 'true'
+        uses: actions/upload-artifact@v2
+        with:
+          name: code-coverage-report
+          path: output/test/code-coverage.html
+          retention-days: 5
 
       - name: Archive production artifacts
         if: steps.check_files_nodejs_test.outputs.files_exists == 'true'
@@ -254,40 +299,12 @@ jobs:
           path: |
             dist
             !dist/**/*.md
-
-      - name: Archive code coverage results - Nodejs
-        if: steps.check_files_nodejs_test.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v2
-        with:
-          name: code-coverage-report
-          path: output/test/code-coverage.html
-          retention-days: 5
       
-      - name: Archive code coverage results - Python
+      # ---------------------------------------------------------
+      # Run SonarQube scan
+      # ---------------------------------------------------------
+      - name: Run SonarQube Scan - Python
         if: steps.check_files_python_test.outputs.files_exists == 'true'
-        uses: actions/upload-artifact@v2
-        with:
-          name: code-coverage-report
-          path: coverage-reports/coverage.xml
-          retention-days: 5
-    
-      # Enable only when Sonar server is available. It will run Static Code Analysis
-      - name: Run Sonar Scan - Nodejs
-        if: ${{ inputs.sonar-nodejs == 'true' }}
-        uses: sonarsource/sonarqube-scan-action@master
-        with:
-          projectBaseDir: .
-          args: >
-            -Dsonar.projectName=${{ inputs.repo_name }}
-            -Dsonar.projectVersion=1.0.0
-            -Dsonar.verbose=true
-            -Dsonar.projectKey=${{ inputs.repo_name }}
-        env:
-         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-         SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-
-      - name: Run Sonar Scan - Python
-        if: ${{ inputs.sonar-python == 'true' }}
         uses: sonarsource/sonarqube-scan-action@master
         with:
           projectBaseDir: .
@@ -301,25 +318,80 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        continue-on-error: true
       
-      - name: SonarScanner for .NET
-        if: ${{ inputs.sonar-dotnet == 'true' }}
-        uses: submittable/sonarscan-dotnet@v2.1.2
+      - name: Run SonarQube Scan - Nodejs
+        if: steps.check_files_nodejs_test.outputs.files_exists == 'true'
+        uses: sonarsource/sonarqube-scan-action@master
         with:
-          # The key of the SonarQube project
-          sonarProjectKey: ${{ inputs.repo_name }}
-          # The name of the SonarQube project
-          sonarProjectName:  ${{ inputs.repo_name }}
-          # Optional command arguments to dotnet build
-          dotnetBuildArguments: ./${{ inputs.dotnetbuildarguments }}
-          # Optional. Set to 1 or true to not run 'dotnet test' command
-          dotnetDisableTests: true
-          # The SonarQube server URL. For SonarCloud, skip this setting.
-          sonarHostname:  ${{ secrets.SONAR_HOST_URL }}
+          projectBaseDir: .
+          args: >
+            -Dsonar.projectName=${{ inputs.repo_name }}
+            -Dsonar.projectVersion=1.0.0
+            -Dsonar.verbose=true
+            -Dsonar.projectKey=${{ inputs.repo_name }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        continue-on-error: true
       
+      # TODO: update this after step: Check file existence for .NET Testfiles
+      # - name: Run SonarQube Scan - .NET
+      #   if: steps.check_files_dotnet_test.outputs.files_exists == 'true'
+      #   uses: submittable/sonarscan-dotnet@v2.1.2
+      #   with:
+      #     sonarProjectKey: ${{ inputs.repo_name }}
+      #     sonarProjectName:  ${{ inputs.repo_name }}
+      #     dotnetBuildArguments: ./${{ inputs.dotnetbuildarguments }}
+      #     dotnetDisableTests: true
+      #     sonarHostname:  ${{ secrets.SONAR_HOST_URL }}
+      #   env:
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   continue-on-error: true
+
+  # ---------------------------------------------------------------------
+  # 3. Build the Docker container and publish
+  # ---------------------------------------------------------------------
+  build:
+    name: Build Container
+    runs-on: [self-hosted, linux]
+    needs: [setup, test]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of SonarQube reporting
+          fetch-depth: 0
+
+      # ---------------------------------------------------------
+      # Setup Docker
+      # ---------------------------------------------------------
+      - name: Check file existence for Dockerfile
+        id: check_files_docker
+        uses: submittable/file-existence-action@v1
+        with:
+          files: "Dockerfile"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver: docker
+      
+      # ---------------------------------------------------------
+      # Tag, build, publish
+      # ---------------------------------------------------------
       # Reads the latest tag on the repo and increments its minor verions
       # Increment style can be changed by including a #major, #minor, or #patch in a commit message
       - name: Bump version and push tag
@@ -352,8 +424,8 @@ jobs:
             type=raw,value=${{ steps.extract_ref_tag.outputs.branch }}
             type=raw,value=${{ GitHub.sha }}
       
-      # Build, Tag and Push the docker image to Github Container Registry
-      - name: Build, Tag and Push Docker Image
+      # Build, Tag, and Push the docker image to Github Container Registry
+      - name: Build, Tag, and Push Docker Image
         # if: steps.check_files_docker.outputs.files_exists == 'true'
         uses: docker/build-push-action@v2.7.0
         with:
@@ -376,6 +448,9 @@ jobs:
           release_name: ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
 
+      # ---------------------------------------------------------
+      # Notifications
+      # ---------------------------------------------------------
       # Sends a slack notification to slack build channel on Success
       - name: Slack Notification - On Success
         if: endsWith(GitHub.ref, 'main') && success()

--- a/caller-examples/multi-pipeline-example-workflow.yml
+++ b/caller-examples/multi-pipeline-example-workflow.yml
@@ -1,50 +1,55 @@
-#This workflow is for multi-projects living in the same repo.
-#For this example, we use the fund-distribution project (.Net), however this example can be be used with any project (NodeJS, Python etc).
+# This workflow is for multi-projects living in the same repo.
+# For this example, we use the fund-distribution project (.Net), however this example can be be used with any project (NodeJS, Python etc).
 name: funds-distribution-payment-processing
 
 on:
-  push:
-    branches:
-      - '*'
   pull_request:
     branches: [ main ]
 
   workflow_dispatch:
 
 jobs:
-  
-  #Run Tests, Sonar Scans, Build and Publish Docker Image
+  # Multi-pipeline
+  # Run Tests, Sonar Scans, Build and Publish Docker Image
   funds-distribution:
       uses: submittable/github-actions/.github/workflows/ci.yml@main
       with:
+        # ---------------------------------------------------------
+        # General project properties
+        # ---------------------------------------------------------
+        repo_name: funds-distribution               # Name of the repository
+        image_name: submittable/funds-distribution  # Name of the owner and repository
+        sem-release: false                          # Enable or disable a semantic release
+        file: FundsDistribution/Dockerfile          # Dockerfile name
+        context: .                                  # Directory of the Dockerfile
+
+        # ---------------------------------------------------------
+        # Set build type for Nodejs, Python, or .NET
+        # ---------------------------------------------------------
         file_check_path_dotnet: "FundsDistribution.sln"
         dotnetbuildarguments: 'FundsDistribution/FundsDistribution.Api.csproj'
-        repo_name: funds-distribution #CHANGE this to the name of the project
-        image_name: ${{ github.repository }}
-        context: .
-        file: FundsDistribution/Dockerfile
-      ########## ENABLE OR DISABLE SONAR SCAN. Default is "false" ##############################
-        sonar-dotnet: false
-      ################Enable Semantic Release###################
-        sem-release: false
       secrets:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   funds-distribution-payment-processing:
-      needs: funds-distribution
+      needs: funds-distribution # This job will start only after this specified job
       uses: submittable/github-actions/.github/workflows/ci.yml@main
       with:
+        # ---------------------------------------------------------
+        # General project properties
+        # ---------------------------------------------------------
+        repo_name: funds-distribution-payment-processing
+        image_name: submittable/funds-distribution-payment-processing
+        sem-release: false
+        context: .
+        file: FundsDistribution.PaymentProcessingService/Dockerfile
+
+        # ---------------------------------------------------------
+        # Set build type for Nodejs, Python, or .NET
+        # ---------------------------------------------------------
         file_check_path_dotnet: "FundsDistribution.sln"
         dotnetbuildarguments: 'FundsDistribution.PaymentProcessingService/FundsDistribution.PaymentProcessingService.csproj'
-        repo_name: funds-distribution-payment-processing #CHANGE this to the name of the project
-        image_name: submittable/funds-distribution-payment-processing
-        context: . #CHANGE this value to the appropriate location of your dockerfile eg ./project default is "." for root directory
-        file: FundsDistribution.PaymentProcessingService/Dockerfile
-      ########## ENABLE OR DISABLE SONAR SCAN. Default is "false" ##############################
-        sonar-dotnet: false
-      ################Enable Semantic Release###################
-        sem-release: false
       secrets:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/caller-examples/reusable-workflow.yml
+++ b/caller-examples/reusable-workflow.yml
@@ -1,5 +1,4 @@
-name: Reusable Workflow 2.0 #CHANGE this to the project or repo name
-#This reusable workflows tests and scans the code for any vulnerabilities. Currently working on Python, Nodejs and .Net projects.
+name: Reusable Workflow 3.0
 
 on:
   pull_request:
@@ -8,37 +7,57 @@ on:
   workflow_dispatch:
 
 jobs:
-  
-  #Run Tests, Sonar Scans, Build and Publish Docker Image
+  # Run Tests, SonarQube Scans, Build and Publish Docker Image
   ci:
       uses: submittable/github-actions/.github/workflows/ci.yml@main
       with:
-      ##############SET BUILDER VERSION - CHOOSE ONE (OPTIONAL)################
-        nodejs_version: '15.x' #Choose which node version [10.x, 12.x, 14.x, 15.x]. Default is 15.x
-        dotnet_version: '5.0.x' #choose which dotnet version default is 5.0.x
-        python_version: '3.6' #Choose which python version [3.6, 3.7, 3.8, 3.9]. default is 3.6
-      ##############SET BUILD TYPE NODEJS, PYTHON OR .NET - CHOOSE ONE (REQUIRED)################
-        file_check_path_python: "nofile" #CHANGE this to a file name or path to the file to set build type to Python ex: requirement.txt or /Source/requirement.txt (absolute/full path)
-        file_check_path_nodejs: "nofile" #CHANGE this to a file name or path to the file to set build type to Node ex: package.json or /src/package.json (absolute/full path)
-        file_check_path_dotnet: "nofile" #CHANGE this to a file name or path to the file to set build type to .Net ex: SQSListener.csproj or /SQSListener/SQSListener/SQSListener.csproj (absolute/full path)
-      ###########################################################################################
-      ##############UNIT TESTS - CHOOSE AN OPTION (OPTIONAL)################
-        file_check_path_nodejs_test: "nofile" #CHANGE this to the location of your test file for python ex: package.json or /src/package.json
-        file_check_path_python_test: "nofile" #CHANGE this to the location of your test file for python ex: requirement.txt or /Source/requirement.txt
-      ######################################################################
-      ########## ENABLE OR DISABLE SONAR SCAN. Default is "false" ##############################
-        sonar-python: false
-        sonar-dotnet: false
-        sonar-nodejs: false
-      ################Enable Semantic Release###################
-        sem-release: false
-      ##########FOR .NET SONAR SCAN ONLY##################
-        dotnetbuildarguments: 'src/Submittable.Api' #Set the path to dotnet build for SonarQube. See https://github.com/submittable/funds-distribution-tool
-      ###############################################
-        repo_name: submittable-test-python-repo #CHANGE this to the name of the project
-        image_name: ${{ github.repository }}
-        context: . #CHANGE this value to the appropriate location of your dockerfile eg ./project/ default is "." for root directory
-        file: 'Dockerfile' #CHANGE this value to the appropriate location of your dockerfile eg project/Dockerfile default is "Dockerfile" for dockerfile liviing in root directory
+        # NOTE: you do not have to fill out the values below.
+        # The values below are defaults and some such as repo_name
+        # have functions to detect the repo name. So, if you'd like
+        # to override the defaults then uncomment the fields below
+        # and update them. 
+
+        # ---------------------------------------------------------
+        # General project properties
+        # ---------------------------------------------------------
+        # repo_name: 'your-repo'                # Name of the repository
+        # image_name: 'submittable/your-repo'   # Name of the owner and repository
+        # sem-release: true                     # Enable or disable a semantic release
+        # file: 'Dockerfile'                    # Dockerfile name
+        # context: .                            # Directory of the Dockerfile
+
+        # ---------------------------------------------------------
+        # Set build type for Nodejs, Python, or .NET
+        # ---------------------------------------------------------
+        # file_check_path_python: "requirements.txt"
+        # file_check_path_nodejs: "package.json"
+        # file_check_path_dotnet: "*.sln"
+
+        # ---------------------------------------------------------
+        # Set builder version
+        # ---------------------------------------------------------
+        # nodejs_version: '15.x'
+        # dotnet_version: '5.0.x'
+        # python_version: '3.6'
+
+        # ---------------------------------------------------------
+        # Unit tests folder location
+        # ---------------------------------------------------------
+        # file_check_path_nodejs_test: "src/__tests__/*"
+        # file_check_path_python_test: "tests/*"
+        
+        # ---------------------------------------------------------
+        # Enable or disable SonarQube scan
+        # ---------------------------------------------------------
+        # DEPRECATED: run SonarQube scan when unit tests are identified
+        # sonar-python: true
+        # sonar-dotnet: false
+        # sonar-nodejs: false
+        
+        # ---------------------------------------------------------
+        # For .NET SonarQube scan only
+        # ---------------------------------------------------------
+        # dotnetbuildarguments: 'src/Submittable.Api' # Set the path to dotnet build for SonarQube
       secrets:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}


### PR DESCRIPTION
Reverts submittable/github-actions#27

This PR brings back the original PR which was https://github.com/submittable/github-actions/pull/26. Nothing has changed in the code since this PR has been reverted. 

I reverted because I tested this soon after it was merged into main on Friday, however, it failed. But, I believe it was an expected error on my part because my steps were:
1. PR merged into main
2. Checkout of a repo using this and did not make any changes
This is where I believe I made an error. Semantic versioning was enabled here and because of that it was looking for a previous commit in this branch which didnt exist `No new commits since previous tag. Skipping...`. Which led to the error `Input required and not supplied: tag_name` since it skipped this step. The solution to test would be to make a commit before manually triggering the CI pipeline so it can generate a tag. 
4. Manually triggered the CI
5. Failed

Note that these changes are backwards compatible. 