### PR TITLE
Add Flag for Unit Tests Enablement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,17 @@ on:
         type: string
       
       # ---------------------------------------------------------
+      # Check to enable the unit tests
+      # ---------------------------------------------------------
+      # TODO: run-python-tests
+      # TODO: run-nodejs-tests
+      run-dotnet-tests:
+        description: Whether to run .NET unit tests
+        default: 'false'
+        required: false
+        type: string
+      
+      # ---------------------------------------------------------
       # Identify the location of the unit tests
       # ---------------------------------------------------------
       file_check_path_python_test:
@@ -251,9 +262,9 @@ jobs:
         run: npm test
       
       - name: Run .NET tests
-        if: steps.check_files_dotnet_test.outputs.files_exists == 'true'
+        if: ${{ inputs.run-dotnet-tests == 'true' && steps.check_files_dotnet_test.outputs.files_exists == 'true' }}
         run: dotnet test --logger trx
-        continue-on-error: true # TODO: Enable this to fail when unit tests fails
+        # continue-on-error: true # TODO: Enable this to fail when unit tests fails
 
       # ---------------------------------------------------------
       # Build the project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ on:
         type: string
 
       # ---------------------------------------------------------
-      # Check to enable SonrQube scan for project
+      # Check to enable SonarQube scan for project
       # ---------------------------------------------------------
       sonar-python:
         description: Whether to Scan code using SonarQube
@@ -99,10 +99,18 @@ on:
         type: string
       
       # ---------------------------------------------------------
-      # Check to enable the unit tests
+      # Check to enable running the unit tests
       # ---------------------------------------------------------
-      # TODO: run-python-tests
-      # TODO: run-nodejs-tests
+      run-python-tests:
+        description: Whether to run python unit tests
+        default: 'false'
+        required: false
+        type: string
+      run-nodejs-tests:
+        description: Whether to run node unit tests
+        default: 'false'
+        required: false
+        type: string
       run-dotnet-tests:
         description: Whether to run .NET unit tests
         default: 'false'
@@ -254,11 +262,11 @@ jobs:
       # Run tests
       # ---------------------------------------------------------
       - name: Run Python tests
-        if: steps.check_files_python_test.outputs.files_exists == 'true'
+        if: ${{ inputs.run-python-tests == 'true' && steps.check_files_python_test.outputs.files_exists == 'true' }}
         run: python -m pytest --cov-report xml:coverage.xml --cov .
       
       - name: Run Nodejs tests
-        if: steps.check_files_nodejs_test.outputs.files_exists == 'true'
+        if: ${{ inputs.run-nodejs-tests == 'true' && steps.check_files_nodejs_test.outputs.files_exists == 'true' }}
         run: npm test
       
       - name: Run .NET tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,7 @@ jobs:
           files: "${{ inputs.file_check_path_nodejs_test }}"
 
       - name: Check file existence for .NET Testfiles
+        if: steps.check_files_dotnet.outputs.files_exists == 'true'
         id: check_files_dotnet_test
         uses: submittable/file-existence-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,6 @@ jobs:
       - name: Run .NET tests
         if: ${{ inputs.run-dotnet-tests == 'true' && steps.check_files_dotnet_test.outputs.files_exists == 'true' }}
         run: dotnet test --logger trx
-        # continue-on-error: true # TODO: Enable this to fail when unit tests fails
 
       # ---------------------------------------------------------
       # Build the project

--- a/caller-examples/reusable-workflow.yml
+++ b/caller-examples/reusable-workflow.yml
@@ -46,6 +46,7 @@ jobs:
         # ---------------------------------------------------------
         # file_check_path_nodejs_test: "src/__tests__/*"
         # file_check_path_python_test: "tests/*"
+        # file_check_path_dotnet_test: "*.Test/*.Test.csproj"
         
         # ---------------------------------------------------------
         # Enable or disable SonarQube scan

--- a/caller-examples/reusable-workflow.yml
+++ b/caller-examples/reusable-workflow.yml
@@ -42,6 +42,13 @@ jobs:
         # python_version: '3.6'
 
         # ---------------------------------------------------------
+        # Enable or disable running the unit tests
+        # ---------------------------------------------------------
+        # run-python-tests: false
+        # run-nodejs-tests: false
+        # run-dotnet-tests: false
+
+        # ---------------------------------------------------------
         # Unit tests folder location
         # ---------------------------------------------------------
         # file_check_path_nodejs_test: "src/__tests__/*"
@@ -52,7 +59,7 @@ jobs:
         # Enable or disable SonarQube scan
         # ---------------------------------------------------------
         # DEPRECATED: run SonarQube scan when unit tests are identified
-        # sonar-python: true
+        # sonar-python: false
         # sonar-dotnet: false
         # sonar-nodejs: false
         

--- a/caller-examples/reusable-workflow.yml
+++ b/caller-examples/reusable-workflow.yml
@@ -10,13 +10,14 @@ jobs:
   # Run Tests, SonarQube Scans, Build and Publish Docker Image
   ci:
       uses: submittable/github-actions/.github/workflows/ci.yml@main
-      with:
-        # NOTE: you do not have to fill out the values below.
-        # The values below are defaults and some such as repo_name
-        # have functions to detect the repo name. So, if you'd like
-        # to override the defaults then uncomment the fields below
-        # and update them. 
-
+      
+      # NOTE: you do not have to fill out the values below.
+      # The values below are defaults and some such as repo_name
+      # have functions to detect the repo name. So, if you'd like
+      # to override the defaults then uncomment 'with' and the fields below
+      # and update them.
+      
+      # with:
         # ---------------------------------------------------------
         # General project properties
         # ---------------------------------------------------------


### PR DESCRIPTION
# What does this change do?

- Add flag to allow clients using the Reusable CI Pipeline to enable running unit tests. The result would be if unit tests fail during execution then the CI pipeline will not continue to the build step. 
- Update reusable workflow caller to comment out `with` object due to error when it is empty.
- Update step `Check file existence for .NET Testfiles` to check for .NET files condition

IMPORTANT: this flag is disabled by default. 
 
To enable it, set the flags value to true based on your repositories language. I recommend running unit tests locally to prevent the CI pipeline from blocking your builds. 

Example:

```yaml
name: Reusable Workflow 2.0

on:
  pull_request:
    branches: [ main ]
  workflow_dispatch:

jobs:
  # Run Tests, Sonar Scans, Build and Publish Docker Image
  ci:
    uses: submittable/github-actions/.github/workflows/ci.yml@main
    with:
      # ...
      run-dotnet-tests: true # For .NET
      run-python-tests: true # For Python
      run-nodejs-tests: true # For Nodejs
```

# Please include a link to the Change Request or Agile Story here

https://submishmash.atlassian.net/browse/SUB-5643
